### PR TITLE
Fixed timeout check

### DIFF
--- a/SetupScripts/Functions.ps1
+++ b/SetupScripts/Functions.ps1
@@ -57,7 +57,7 @@ function EnsureSitefinityIsRunning([String]$url="http://localhost", [String]$suc
               Write-Host "Checking Sitefinity status: ${statusUrl}"
               $response = Invoke-WebRequest $statusUrl -TimeoutSec 300 -UseBasicParsing
 
-              if($elapsed.Elapsed.Minites > $totalWaitMinutes)
+              if($elapsed.Elapsed.TotalMinutes > $totalWaitMinutes)
               {
                 Write-Host "Sitefinity did NOT start in the specified maximum time"
                 break


### PR DESCRIPTION
"Minites" isn't a property on the StopWatch object, so it is always represented as $null, so the comparison to $totalWaitMinutes (10) is always false. Also, TotalMinutes is a more appropriate property because it is the total elapsed span, not just the minutes component of the span.